### PR TITLE
0xSplits USDT disclosure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/disclosures/2025-02-18.md
+++ b/disclosures/2025-02-18.md
@@ -61,7 +61,7 @@ Additionally, Art Blocks has updated our internal scripts to use the patched 0xS
 
 2025-02-18: Art Blocks review of the described mitigation process (internally and with 0xSplits) to ensure it is safe and effective.
 
-2025-02-TBD: Art Blocks published this disclosure; broader communication plan begins.
+2025-02-19: Art Blocks published this disclosure; broader communication plan begins.
 
 ongoing: Art Blocks continues monitoring affected contracts to ensure migration steps are completed.
 

--- a/disclosures/2025-02-18.md
+++ b/disclosures/2025-02-18.md
@@ -11,7 +11,7 @@ At this time, Art Blocks has not observed any damages from this issue; no USDT r
 - Previous Art Blocks `SplitProviderV0` contract: [0x0000000004B100B47f061968a387c82702AFe946](https://etherscan.io/address/0x0000000004B100B47f061968a387c82702AFe946#code)
 - New Art Blocks `SplitProviderV0` contract: [0x000000000ef75C77F6bd0b2Ee166501FbBDb40c8](https://etherscan.io/address/0x000000000ef75C77F6bd0b2Ee166501FbBDb40c8#code)
 
-For existing contracts, Art Blocks has developed a sequence of acitons to be taken by existing core contract admins to migrate to the updated `SplitProvider` contract. The steps are listed in the [Recommended Migration Path](#recommended-migration-path) section.
+For existing contracts, Art Blocks has developed a sequence of actions to be taken by existing core contract admins to migrate to the updated `SplitProvider` contract. The steps are listed in the [Recommended Migration Path](#recommended-migration-path) section.
 
 ### Summary of Damages
 

--- a/disclosures/2025-02-18.md
+++ b/disclosures/2025-02-18.md
@@ -68,5 +68,4 @@ ongoing: Art Blocks continues monitoring affected contracts to ensure migration 
 ## References
 
 - [0xSplits PullSplitFactoryV2.1 Deployment](https://github.com/0xSplits/splits-contracts-monorepo/blob/main/packages/splits-v2/deployments/1.json)
-- [Art Blocks v3.2 SplitProvider Contract](https://etherscan.io/address/0x0000000004B100B47f061968a387c82702AFe946#code)
 - [0xSplits Blog Post](https://splits.org/blog/warning-mainnet-usdt-cannot-be-distributed-from-immutable-v2-splits/)

--- a/disclosures/2025-02-18.md
+++ b/disclosures/2025-02-18.md
@@ -1,0 +1,72 @@
+# Incident Disclosure - 2025-02-18
+
+## Summary
+
+0xSplits v2 has announced an issue where USDT cannot be withdrawn from immutable split contracts on **mainnet only**. This affects all mainnet Art Blocks v3.2 contracts, including all Art Blocks Studio contracts. Their announcement can be found on their public blog [here](https://splits.org/blog/warning-mainnet-usdt-cannot-be-distributed-from-immutable-v2-splits/).
+
+At this time, Art Blocks has not observed any damages from this issue; no USDT royalties have been sent to any of the affected splitter contracts.
+
+0xSplits has provided a patched v2.1 version of their contract to address the issue. Art Blocks subsequently deployed a new immutable `SplitProviderV0` contract that integrates with the patched 0xSplits v2.1 contract.
+
+- Previous Art Blocks `SplitProviderV0` contract: [0x0000000004B100B47f061968a387c82702AFe946](https://etherscan.io/address/0x0000000004B100B47f061968a387c82702AFe946#code)
+- New Art Blocks `SplitProviderV0` contract: [0x000000000ef75C77F6bd0b2Ee166501FbBDb40c8](https://etherscan.io/address/0x000000000ef75C77F6bd0b2Ee166501FbBDb40c8#code)
+
+For existing contracts, Art Blocks has developed a sequence of acitons to be taken by existing core contract admins to migrate to the updated `SplitProvider` contract. The steps are listed in the [Recommended Migration Path](#recommended-migration-path) section.
+
+### Summary of Damages
+
+No damages have been observed at this time.
+
+### Summary of Not Damages
+
+No damages have been observed at this time.
+
+## Background
+
+Art Blocks integrated with 0xSplits v2 in early 2024 while developing the Art Blocks v3.2 contracts. The integration was implemented to achieve compliance with the ERC-2981 NFT Royalty Standard, maximizing the royalty compatibility of future Art Blocks contracts.
+
+Art Blocks did protect against any unforseen issues with the 0xSplits v2 contracts by developing a permissionless `SplitProviderV0` contract layer that allows core contract admins to migrate to a new splitter system at their discretion.
+
+## Recommended Migration Path
+
+The recommended migration path for core contract admins is as follows:
+
+1. Inspect your mainnet core contract on etherscan.io. Read function `splitProvider()` to determine the current address of the `splitProvider`. If the `splitProvider` function does not exist, your contract's version is pre-v3.2 and not affected by the 0xSplits V2 issue.
+
+2. If `splitProvider()` returns address `0x0000000004B100B47f061968a387c82702AFe946`, your contract is affected by the 0xSplits V2 issue, and you should proceed to step 3. Otherwise, your contract is not affected by the 0xSplits V2 issue, and no action is required.
+
+3. From admin wallet, call the `updateSplitProvider()` function with the address of the updated Art Blocks `SplitProvider` contract, `0x000000000ef75C77F6bd0b2Ee166501FbBDb40c8`.
+
+4. For each existing project, the admin or artist should call `updateProjectArtistAddress`, with the existing artist address (to avoid changes). This will trigger a new, patched splitter contract to be assigned to as the recipient of the project's royalties. Note that any new projects added to the core contract will automatically be assigned splitters from the patched splitter contract, resolving all issues going forward.
+
+5. Notify the Art Blocks team that the migration has been completed.
+
+_As is the case with any royalty updates, any previously created orders on some marketplaces may remain stale and could still send royalties to the old splitter contract. However, for new orders, the patched splitter contract will be used. Please notify the Art Blocks team so we can alert third party marketplaces to refresh any cached royalty information._
+
+## Details of the Incident
+
+Details of the incident are available in the 0xSplits announcement [here](https://splits.org/blog/warning-mainnet-usdt-cannot-be-distributed-from-immutable-v2-splits/). In summary, USDT has a unique approval requirement (beyond the standard ERC-20 specification) that sometimes prevented the 0xSplits V2 system of contracts from withdrawing USDT from the splitter contract.
+
+## Details of the Fix
+
+The patched 0xSplits v2.1 contracts resolve the described issue, and Art Blocks has deployed a new `SplitProvider` contract that integrates with the patched 0xSplits v2.1 contracts, as well as published migration steps for existing core contract admins to migrate to the patched 0xSplits v2.1 contracts.
+
+Additionally, Art Blocks has updated our internal scripts to use the patched 0xSplits v2.1 contracts by default for all new core contract deployments.
+
+## Timeline of Events
+
+2025-02-12: 0xSplits published blog post warning of the issue.
+
+2025-02-13: Art Blocks became aware of the blog post, and began development of a patch and migration steps for existing core contract admins.
+
+2025-02-18: Art Blocks review of the described mitigation process (internally and with 0xSplits) to ensure it is safe and effective.
+
+2025-02-TBD: Art Blocks published this disclosure; broader communication plan begins.
+
+ongoing: Art Blocks continues monitoring affected contracts to ensure migration steps are completed.
+
+## References
+
+- [0xSplits PullSplitFactoryV2.1 Deployment](https://github.com/0xSplits/splits-contracts-monorepo/blob/main/packages/splits-v2/deployments/1.json)
+- [Art Blocks v3.2 SplitProvider Contract](https://etherscan.io/address/0x0000000004B100B47f061968a387c82702AFe946#code)
+- [0xSplits Blog Post](https://splits.org/blog/warning-mainnet-usdt-cannot-be-distributed-from-immutable-v2-splits/)

--- a/disclosures/readme.md
+++ b/disclosures/readme.md
@@ -6,6 +6,8 @@ In general, security disclosures will be made public in this directory once all 
 
 ## Disclosure Reports
 
-| Title                  | Disclosure Report | Link                           |
-| ---------------------- | ----------------- | ------------------------------ |
-| Leaked Deployer Wallet | 2023-11-13        | [Report Link](./2023-11-13.md) |
+| Title                          | Disclosure Report | Link                           |
+| ------------------------------ | ----------------- | ------------------------------ |
+| Leaked Deployer Wallet         | 2023-11-13        | [Report Link](./2023-11-13.md) |
+| Malicious Artist Front-Running | 2024-03-20        | [Report Link](./2024-03-20.md) |
+| 0xSplits v2 Issue              | 2025-02-18        | [Report Link](./2025-02-18.md) |


### PR DESCRIPTION
0xSplitsV2 contracts were recently announced to have an issue with withdrawing USDT tokens on mainnet.

For safety, new SplitProviderV0 contracts are deployed to all networks, and all new contracts will use the new SplitProvider by default.

This adds a disclosure that includes mitigation steps for any affected contracts.