### PR TITLE
Disclosure for 0xSplits V2.1 issue

### DIFF
--- a/disclosures/2025-07-23.md
+++ b/disclosures/2025-07-23.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-0xSplits v2.1 has announced an issue where USDT cannot be withdrawn from immutable split contracts on **mainnet only**. This affects the 0xSplit splitter contracts used by all mainnet Art Blocks v3.2 contracts, including all Art Blocks Studio contracts. 0xSplits had previously provided a patched v2.1 version of their contract that was believed to address the issue, which Art Blocks provided an upgrade path for described in [2025-02-19](https://github.com/artblocks-studio/artblocks-contracts/blob/main/disclosures/2025-02-19.md), but it was later discovered that the issue persisted. 0xSplits has now provided a new patched v2.2 version of their contract that addresses the issue. Art Blocks has deployed a new immutable `SplitProviderV0` contract that integrates with the patched 0xSplits v2.2 contract.
+0xSplits v2.1 has announced an issue where USDT cannot be withdrawn from immutable split contracts on **mainnet only**. This affects the 0xSplit splitter contracts used by all mainnet Art Blocks v3.2 contracts, including all Art Blocks Studio contracts. 0xSplits had previously provided a patched v2.1 version of their contract that was believed to address the issue, which Art Blocks provided an upgrade path for described in [2025-02-19](https://github.com/ArtBlocks/artblocks-security/blob/main/disclosures/2025-02-19.md), but it was later discovered that the issue persisted. 0xSplits has now provided a new patched v2.2 version of their contract that addresses the issue. Art Blocks has deployed a new immutable `SplitProviderV0` contract that integrates with the patched 0xSplits v2.2 contract.
 
 At this time, Art Blocks has not observed any damages from this issue; no USDT royalties have been sent to any of the affected splitter contracts.
 

--- a/disclosures/2025-07-23.md
+++ b/disclosures/2025-07-23.md
@@ -12,7 +12,7 @@ At this time, Art Blocks has not observed any damages from this issue; no USDT r
 - Previous 0xSplits v2.1 `SplitProvider` contract: [0x000000000ef75C77F6bd0b2Ee166501FbBDb40c8](https://etherscan.io/address/0x000000000ef75C77F6bd0b2Ee166501FbBDb40c8#code)
 - New Art Blocks `SplitProviderV0` contract that integrates with the patched 0xSplits v2.2 contract: [0x00000000CE5EEBAB4B5C2d6Cc5E73eaafA634DB3](https://etherscan.io/address/0x00000000CE5EEBAB4B5C2d6Cc5E73eaafA634DB3#code)
 
-For existing contracts, the same actions as described in [2025-02-19](https://github.com/artblocks-studio/artblocks-contracts/blob/main/disclosures/2025-02-19.md) should be taken to migrate to the updated `SplitProvider` contract. The steps are listed in the [Recommended Migration Path](#recommended-migration-path) section.
+For existing contracts, the same actions as described in [2025-02-19](https://github.com/ArtBlocks/artblocks-security/blob/main/disclosures/2025-02-19.md) should be taken to migrate to the updated `SplitProvider` contract. The steps are listed in the [Recommended Migration Path](#recommended-migration-path) section.
 
 ### Summary of Damages
 

--- a/disclosures/2025-07-23.md
+++ b/disclosures/2025-07-23.md
@@ -1,0 +1,74 @@
+# Incident Disclosure - 2025-07-23
+
+## Summary
+
+0xSplits v2.1 has announced an issue where USDT cannot be withdrawn from immutable split contracts on **mainnet only**. This affects the 0xSplit splitter contracts used by all mainnet Art Blocks v3.2 contracts, including all Art Blocks Studio contracts. 0xSplits had previously provided a patched v2.1 version of their contract that was believed to address the issue, which Art Blocks provided an upgrade path for described in [2025-02-19](https://github.com/artblocks-studio/artblocks-contracts/blob/main/disclosures/2025-02-19.md), but it was later discovered that the issue persisted. 0xSplits has now provided a new patched v2.2 version of their contract that addresses the issue. Art Blocks has deployed a new immutable `SplitProviderV0` contract that integrates with the patched 0xSplits v2.2 contract.
+
+At this time, Art Blocks has not observed any damages from this issue; no USDT royalties have been sent to any of the affected splitter contracts.
+
+0xSplits has provided a patched v2.2 version of their contract to address the issue. Art Blocks subsequently deployed a new immutable `SplitProviderV0` contract that integrates with the patched 0xSplits v2.2 contract.
+
+- Previous Art Blocks `SplitProviderV0` contract: [0x0000000004B100B47f061968a387c82702AFe946](https://etherscan.io/address/0x0000000004B100B47f061968a387c82702AFe946#code)
+- Previous 0xSplits v2.1 `SplitProvider` contract: [0x000000000ef75C77F6bd0b2Ee166501FbBDb40c8](https://etherscan.io/address/0x000000000ef75C77F6bd0b2Ee166501FbBDb40c8#code)
+- New Art Blocks `SplitProviderV0` contract that integrates with the patched 0xSplits v2.2 contract: [0x00000000CE5EEBAB4B5C2d6Cc5E73eaafA634DB3](https://etherscan.io/address/0x00000000CE5EEBAB4B5C2d6Cc5E73eaafA634DB3#code)
+
+For existing contracts, the same actions as described in [2025-02-19](https://github.com/artblocks-studio/artblocks-contracts/blob/main/disclosures/2025-02-19.md) should be taken to migrate to the updated `SplitProvider` contract. The steps are listed in the [Recommended Migration Path](#recommended-migration-path) section.
+
+### Summary of Damages
+
+No damages have been observed at this time.
+
+## Background
+
+Art Blocks integrated with 0xSplits v2 in early 2024 while developing the Art Blocks v3.2 contracts. The integration was implemented to achieve compliance with the ERC-2981 NFT Royalty Standard, maximizing the royalty compatibility of future Art Blocks contracts.
+
+Art Blocks did protect against any unforseen issues with the 0xSplits v2 contracts by developing a permissionless `SplitProviderV0` contract layer that allows core contract admins to migrate to a new splitter system at their discretion.
+
+## Recommended Migration Path
+
+The recommended migration path for core contract admins is as follows:
+
+1. Inspect your mainnet core contract on etherscan.io. Read function `splitProvider()` to determine the current address of the `splitProvider`. If the `splitProvider` function does not exist, your contract's version is pre-v3.2 and not affected by the 0xSplits V2 issue and no action is required.
+
+2. If `splitProvider()` returns address `0x0000000004B100B47f061968a387c82702AFe946` or `0x000000000ef75C77F6bd0b2Ee166501FbBDb40c8`, your contract is affected by the 0xSplits V2 or V2.1 issues, and you should proceed to step 3. Otherwise, your contract is not affected by the 0xSplits V2 or V2.1 issues, and no action is required.
+
+3. Connect your admin wallet to etherscan (via the `connect to web3` button). Call the `updateSplitProvider()` function with the address of the updated Art Blocks `SplitProvider` contract, `0x00000000CE5EEBAB4B5C2d6Cc5E73eaafA634DB3`.
+
+   - _Note: to find admin wallet, read the `admin()` function of the core contract to be directed to the adminACL contract, then read the `superAdmin()` function of the adminACL contract to view the admin wallet._
+
+4. For each existing project, the admin or artist should call `updateProjectArtistAddress`, with the existing artist address (to avoid changes). This will trigger a new, patched splitter contract to be assigned to as the recipient of the project's royalties. Note that any new projects added to the core contract will automatically be assigned splitters from the patched splitter contract, resolving all issues going forward.
+
+   - _Note: to determine the artist address for each existing project, the core contract's read function `projectIdToArtistAddress()` may be called on etherscan. additionly, the starting project ID can be found by calling the `startingProjectId()` function, and the ending project ID can be found by calling the `nextProjectId()` function and subtracting 1._
+
+5. For each existing project, you will have a new splitter contract address that is assigned to receive project royalties. The new splitter contract address can be found by reading the `projectIdToFinancials(<projectId>)` function on etherscan. The last item in the returned array is the splitter contract address. The splitter can be viewed on 0xSplits website.
+
+6. Notify the Art Blocks team that the migration has been completed.
+
+_As is the case with any royalty updates, any previously created orders on some marketplaces may remain stale and could still send royalties to the old splitter contract. However, for new orders, the patched splitter contract will be used. Please notify the Art Blocks team so we can alert third party marketplaces to refresh any cached royalty information._
+
+## Details of the Incident
+
+Details of the incident are available in the 0xSplits announcement [here](https://splits.org/blog/dont-send-mainnet-usdt-to-immutable-v2-1-splits/). In summary, USDT has a unique approval requirement (beyond the standard ERC-20 specification) that sometimes prevented the 0xSplits V2.1 system of contracts from withdrawing USDT from the splitter contract.
+
+## Details of the Fix
+
+The patched 0xSplits v2.2 contracts resolve the described issue, and Art Blocks has deployed a new `SplitProvider` contract that integrates with the patched 0xSplits v2.2 contracts, as well as published migration steps for existing core contract admins to migrate to the patched 0xSplits v2.2 contracts.
+
+Additionally, Art Blocks has updated our internal scripts to use the patched 0xSplits v2.2 contracts by default for all new core contract deployments.
+
+## Timeline of Events
+
+2025-07-02: 0xSplits published blog post warning of the issue, with a patch yet to be released.
+
+2025-07: 0xSplits published V2.2 release https://github.com/0xSplits/splits-contracts-monorepo/releases/tag/splits-v2.2
+
+2025-07-23: Art Blocks deployed the new `SplitProviderV0` contract that integrates with the patched 0xSplits v2.2 contract.
+
+2025-07-23: Art Blocks published this disclosure; communication plan begins.
+
+ongoing: Art Blocks continues monitoring affected contracts to ensure migration steps are completed.
+
+## References
+
+- [0xSplits PullSplitFactoryV2.2 Deployment](https://github.com/0xSplits/splits-contracts-monorepo/blob/main/packages/splits-v2/deployments/1.json)
+- [0xSplits Blog Post](https://splits.org/blog/dont-send-mainnet-usdt-to-immutable-v2-1-splits/)

--- a/disclosures/readme.md
+++ b/disclosures/readme.md
@@ -11,3 +11,4 @@ In general, security disclosures will be made public in this directory once all 
 | Leaked Deployer Wallet         | 2023-11-13        | [Report Link](./2023-11-13.md) |
 | Malicious Artist Front-Running | 2024-03-20        | [Report Link](./2024-03-20.md) |
 | 0xSplits v2 Issue              | 2025-02-19        | [Report Link](./2025-02-19.md) |
+| 0xSplits v2.1 Issue            | 2025-07-23        | [Report Link](./2025-07-23.md) |


### PR DESCRIPTION
Add disclosure for 0xSplits V2.1 issue.

This is very similar to the disclosure for the 0xSplits V2 issue from February 2025. The same upgrade path is described in this disclosure as described in the V2 disclosure.

Reference 0xSplits blog post for context: https://splits.org/blog/dont-send-mainnet-usdt-to-immutable-v2-1-splits/

fixes https://linear.app/art-blocks/issue/PRO-1934/publish-new-disclosure-for-0xsplits-v22